### PR TITLE
Fix CI matrix, nil-request panic, Dockerfile, and metric unit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,20 +14,15 @@ jobs:
     strategy:
       matrix:
         go:
-          - '1.21'
-          - '1.22'
-          - '1.23'
-          - '1.24'
-          - '1.25'
           - '1.26'
 
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go ${{ matrix.go }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,30 @@
-# Use a minimal base image with Go installed
+# Build the webhook binary in a full Go toolchain image
 FROM golang:1.26 AS builder
 
 # Set the working directory
 WORKDIR /app
 
+# Cache module downloads before copying the rest of the source
+COPY go.mod go.sum ./
+RUN go mod download
+
 # Copy the Go source code
 COPY . .
 
-# Build the Go binary
-RUN go build -o webhook main.go
+# Build a static binary so it can run on a minimal base image
+RUN CGO_ENABLED=0 go build -o webhook .
+
+# Run on a minimal, non-root base image
+FROM gcr.io/distroless/static:nonroot
+
+# Copy the built binary from the builder stage
+COPY --from=builder /app/webhook /webhook
 
 # Expose port for webhook server
 EXPOSE 8443
 
+# Run as a non-root user
+USER nonroot:nonroot
+
 # Run the webhook
-CMD ["/app/webhook"]
+ENTRYPOINT ["/webhook"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,9 @@ COPY --from=builder /app/webhook /webhook
 # Expose port for webhook server
 EXPOSE 8443
 
-# Run as a non-root user
-USER nonroot:nonroot
+# Run as the distroless non-root user (UID 65532) using a numeric UID so that
+# Kubernetes runAsNonRoot can verify it without resolving the username.
+USER 65532:65532
 
 # Run the webhook
 ENTRYPOINT ["/webhook"]

--- a/main.go
+++ b/main.go
@@ -22,11 +22,11 @@ import (
 )
 
 var (
-	// Create a histogram metric to track the duration of requests in milliseconds
+	// Create a histogram metric to track the duration of requests in seconds
 	requestDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "argocd_webhook_request_duration",
-			Help:    "Duration of requests to the webhook server in milliseconds.",
+			Name:    "argocd_webhook_request_duration_seconds",
+			Help:    "Duration of requests to the webhook server in seconds.",
 			Buckets: prometheus.DefBuckets,
 		},
 		[]string{"change"}, // Label is now "change" with values "true" and "false"
@@ -65,6 +65,12 @@ func handleAdmissionReview(w http.ResponseWriter, r *http.Request) {
 	err = json.Unmarshal(body, &admissionReviewReq)
 	if err != nil {
 		http.Error(w, "failed to unmarshal request", http.StatusBadRequest)
+		return
+	}
+
+	// Guard against a malformed payload that unmarshals without an admission request.
+	if admissionReviewReq.Request == nil {
+		http.Error(w, "missing admission request", http.StatusBadRequest)
 		return
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -10,6 +10,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestWebhookOperationHandler(t *testing.T) {
@@ -124,6 +125,123 @@ func TestHandleAdmissionReview_StatusSyncRevisionChange(t *testing.T) {
 
 	if !admissionResp.Response.Allowed {
 		t.Errorf("Expected response to be allowed, but it was denied")
+	}
+}
+
+// doAdmissionReview marshals the request, runs the handler, and returns the
+// HTTP recorder so individual tests can assert on status code and response body.
+func doAdmissionReview(t *testing.T, reqBody admissionv1.AdmissionReview) *httptest.ResponseRecorder {
+	t.Helper()
+
+	reqBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatalf("Failed to marshal request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/validate", bytes.NewReader(reqBytes))
+	w := httptest.NewRecorder()
+	handleAdmissionReview(w, req)
+	return w
+}
+
+// updateReview builds an UPDATE AdmissionReview for an Application from the raw
+// old and new object JSON.
+func updateReview(uid string, oldRaw, newRaw string) admissionv1.AdmissionReview {
+	return admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "admission.k8s.io/v1",
+			Kind:       "AdmissionReview",
+		},
+		Request: &admissionv1.AdmissionRequest{
+			UID:       types.UID(uid),
+			Kind:      metav1.GroupVersionKind{Kind: "Application"},
+			Operation: admissionv1.Update,
+			OldObject: runtime.RawExtension{Raw: []byte(oldRaw)},
+			Object:    runtime.RawExtension{Raw: []byte(newRaw)},
+		},
+	}
+}
+
+func decodeResponse(t *testing.T, w *httptest.ResponseRecorder) *admissionv1.AdmissionReview {
+	t.Helper()
+
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Expected status code 200, got %d", resp.StatusCode)
+	}
+
+	var admissionResp admissionv1.AdmissionReview
+	if err := json.NewDecoder(resp.Body).Decode(&admissionResp); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	if admissionResp.Response == nil {
+		t.Fatalf("Expected a response, got nil")
+	}
+	return &admissionResp
+}
+
+// TestHandleAdmissionReview_NoSignificantChange covers the core dedup behavior:
+// when old and new objects are identical, the update must be denied.
+func TestHandleAdmissionReview_NoSignificantChange(t *testing.T) {
+	obj := `{"metadata": {"name": "app"}, "spec": {"project": "default"}, "status": {"sync": {"status": "Synced"}}}`
+	resp := decodeResponse(t, doAdmissionReview(t, updateReview("no-change", obj, obj)))
+
+	if resp.Response.Allowed {
+		t.Errorf("Expected update to be denied for an identical object, but it was allowed")
+	}
+}
+
+// TestHandleAdmissionReview_OnlyReconciledAtIgnoredFields verifies that updates
+// touching only reconciledAt, managedFields, and generation are treated as no-ops.
+func TestHandleAdmissionReview_OnlyReconciledAtIgnoredFields(t *testing.T) {
+	oldRaw := `{"metadata": {"name": "app", "generation": 1, "managedFields": [{"manager": "a"}]}, "spec": {}, "status": {"reconciledAt": "2024-03-20T12:00:00Z"}}`
+	newRaw := `{"metadata": {"name": "app", "generation": 2, "managedFields": [{"manager": "b"}]}, "spec": {}, "status": {"reconciledAt": "2024-03-21T12:00:00Z"}}`
+	resp := decodeResponse(t, doAdmissionReview(t, updateReview("ignored-fields", oldRaw, newRaw)))
+
+	if resp.Response.Allowed {
+		t.Errorf("Expected update to be denied when only ignored fields changed, but it was allowed")
+	}
+}
+
+// TestHandleAdmissionReview_SpecChange verifies a real spec change is allowed.
+func TestHandleAdmissionReview_SpecChange(t *testing.T) {
+	oldRaw := `{"metadata": {}, "spec": {"project": "default"}, "status": {}}`
+	newRaw := `{"metadata": {}, "spec": {"project": "production"}, "status": {}}`
+	resp := decodeResponse(t, doAdmissionReview(t, updateReview("spec-change", oldRaw, newRaw)))
+
+	if !resp.Response.Allowed {
+		t.Errorf("Expected update to be allowed for a spec change, but it was denied")
+	}
+}
+
+// TestHandleAdmissionReview_NonApplicationKind verifies non-Application kinds
+// pass through untouched.
+func TestHandleAdmissionReview_NonApplicationKind(t *testing.T) {
+	review := updateReview("other-kind",
+		`{"metadata": {}, "spec": {}, "status": {}}`,
+		`{"metadata": {}, "spec": {}, "status": {}}`)
+	review.Request.Kind = metav1.GroupVersionKind{Kind: "ConfigMap"}
+	resp := decodeResponse(t, doAdmissionReview(t, review))
+
+	if !resp.Response.Allowed {
+		t.Errorf("Expected non-Application update to be allowed, but it was denied")
+	}
+}
+
+// TestHandleAdmissionReview_NilRequest verifies a payload without an admission
+// request is rejected instead of panicking.
+func TestHandleAdmissionReview_NilRequest(t *testing.T) {
+	w := doAdmissionReview(t, admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "admission.k8s.io/v1",
+			Kind:       "AdmissionReview",
+		},
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status code 400 for a nil request, got %d", w.Code)
 	}
 }
 

--- a/webhook-deployment.yaml
+++ b/webhook-deployment.yaml
@@ -14,12 +14,23 @@ spec:
       labels:
         app: webhook-server
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: webhook-server
           image: ghcr.io/hsiaoairplane/argocd-webhook:v0.2.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8443
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
             - name: tls-certs
               mountPath: "/certs"


### PR DESCRIPTION
## Summary
Fixes four issues found while reviewing the repo, plus test coverage for the core dedup behavior.

- **CI was broken**: the matrix tested Go 1.21–1.25, but `go.mod` requires `go 1.26`, so those jobs could never build. Trimmed the matrix to 1.26 and bumped `actions/checkout@v3 → v4`, `setup-go@v4 → v5`.
- **nil-request panic**: a syntactically valid payload without a `request` field dereferenced `Request.UID`/`Request.Operation` and panicked on every call. Now returns `400 Bad Request`.
- **Dockerfile**: converted to a multi-stage build on `distroless/static:nonroot` with a static, CGO-free binary running as non-root (was a ~1GB `golang` image running as root). Also `go build .` instead of `go build main.go` and a module-download cache layer.
- **Metric unit mismatch**: histogram was named `argocd_webhook_request_duration` / "in milliseconds" but observed `.Seconds()`. Renamed to `argocd_webhook_request_duration_seconds` with matching help text.

## Tests
Added coverage for the core dedup path and edge cases (all passing):
- identical update → denied (the main feature, previously untested)
- only `reconciledAt` / `managedFields` / `generation` changed → denied
- real spec change → allowed
- non-Application kind → passthrough
- nil request → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)