### PR TITLE
Harden webhook server, deployment, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,11 @@ jobs:
         with:
           go-version: '1.26'
 
+      # Build golangci-lint from source with the Go 1.26 toolchain. Prebuilt
+      # binaries lag the toolchain and refuse to lint a module that targets a
+      # newer Go than they were built with.
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: latest
+        run: golangci-lint run ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,36 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
+      - name: Check formatting
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not gofmt-formatted:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Go vet
+        run: make vet
+
       - name: Go test
-        run: make test
+        run: go test -race -coverprofile=coverage.out ./...
 
       - name: Go build
         run: make build
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -20,6 +21,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 )
+
+// maxBodyBytes caps the admission request body. An AdmissionReview carries both
+// the old and new object, each up to the ~1.5 MiB etcd limit, so allow headroom.
+const maxBodyBytes = 8 << 20 // 8 MiB
 
 var (
 	// Create a histogram metric to track the duration of requests in seconds
@@ -55,10 +60,19 @@ func handleAdmissionReview(w http.ResponseWriter, r *http.Request) {
 	// Start measuring the request duration
 	start := time.Now()
 
+	// Admission webhooks are only ever called via POST.
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Bound the request body to protect against oversized or slow payloads.
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
 	var admissionReviewReq admissionv1.AdmissionReview
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		http.Error(w, "failed to read request body", http.StatusInternalServerError)
+		http.Error(w, "failed to read request body", http.StatusBadRequest)
 		return
 	}
 
@@ -167,13 +181,25 @@ func removeReconciledAt(obj map[string]interface{}) {
 	}
 }
 
-func sendResponse(w http.ResponseWriter, admissionReviewResp admissionv1.AdmissionReview) {
-	responseBytes, _ := json.Marshal(admissionReviewResp)
-	w.Header().Set("Content-Type", "application/json")
-	w.Write(responseBytes)
+// handleHealth serves liveness and readiness probes.
+func handleHealth(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = io.WriteString(w, "ok")
 }
 
-// Function to record the request duration in milliseconds
+func sendResponse(w http.ResponseWriter, admissionReviewResp admissionv1.AdmissionReview) {
+	responseBytes, err := json.Marshal(admissionReviewResp)
+	if err != nil {
+		http.Error(w, "failed to marshal response", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write(responseBytes); err != nil {
+		log.Errorf("Failed to write response: %v", err)
+	}
+}
+
+// Function to record the request duration in seconds
 func recordRequestDuration(status string, start time.Time) {
 	duration := time.Since(start).Seconds()
 	requestDuration.WithLabelValues(status).Observe(duration)
@@ -232,8 +258,15 @@ func main() {
 
 	addr := fmt.Sprintf(":%s", *port)
 	srv := &http.Server{
-		Addr:    addr,
-		Handler: http.DefaultServeMux,
+		Addr:              addr,
+		Handler:           http.DefaultServeMux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       60 * time.Second,
+		TLSConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		},
 	}
 
 	level, err := log.ParseLevel(*logLevel)
@@ -245,9 +278,13 @@ func main() {
 	// Metrics endpoint
 	http.Handle("/metrics", promhttp.Handler())
 
+	// Liveness and readiness probes
+	http.HandleFunc("/healthz", handleHealth)
+	http.HandleFunc("/readyz", handleHealth)
+
 	// Webhook handler
 	http.HandleFunc("/validate", handleAdmissionReview)
-	log.Info("Starting webhook server on :8443...")
+	log.Infof("Starting webhook server on %s...", addr)
 
 	go func() {
 		if err := srv.ListenAndServeTLS("/certs/tls.crt", "/certs/tls.key"); err != nil && err != http.ErrServerClosed {

--- a/main_test.go
+++ b/main_test.go
@@ -52,7 +52,7 @@ func TestWebhookOperationHandler(t *testing.T) {
 			handleAdmissionReview(w, req)
 
 			resp := w.Result()
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 
 			if resp.StatusCode != http.StatusOK {
 				t.Errorf("Expected status code 200, got %d", resp.StatusCode)
@@ -104,7 +104,7 @@ func TestHandleAdmissionReview_StatusSyncRevisionChange(t *testing.T) {
 	handleAdmissionReview(w, req)
 
 	resp := w.Result()
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("Expected status code 200, got %d", resp.StatusCode)
@@ -166,7 +166,7 @@ func decodeResponse(t *testing.T, w *httptest.ResponseRecorder) *admissionv1.Adm
 	t.Helper()
 
 	resp := w.Result()
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("Expected status code 200, got %d", resp.StatusCode)
@@ -245,6 +245,28 @@ func TestHandleAdmissionReview_NilRequest(t *testing.T) {
 	}
 }
 
+// TestHandleAdmissionReview_MethodNotAllowed verifies non-POST methods are rejected.
+func TestHandleAdmissionReview_MethodNotAllowed(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/validate", nil)
+	w := httptest.NewRecorder()
+	handleAdmissionReview(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("Expected status code 405 for a GET request, got %d", w.Code)
+	}
+}
+
+// TestHandleHealth verifies the health endpoint returns 200 OK.
+func TestHandleHealth(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	w := httptest.NewRecorder()
+	handleHealth(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status code 200 from health endpoint, got %d", w.Code)
+	}
+}
+
 func TestHandleAdmissionReview_StatusReconciledAtChange(t *testing.T) {
 	reqBody := admissionv1.AdmissionReview{
 		TypeMeta: metav1.TypeMeta{
@@ -271,7 +293,7 @@ func TestHandleAdmissionReview_StatusReconciledAtChange(t *testing.T) {
 	handleAdmissionReview(w, req)
 
 	resp := w.Result()
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("Expected status code 200, got %d", resp.StatusCode)

--- a/webhook-deployment.yaml
+++ b/webhook-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: webhook-server
   namespace: argocd
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: webhook-server
@@ -31,6 +31,27 @@ spec:
             capabilities:
               drop:
                 - ALL
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8443
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8443
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
           volumeMounts:
             - name: tls-certs
               mountPath: "/certs"


### PR DESCRIPTION
## Summary
Addresses the remaining hardening items from the repo review (#5–#12).

### Server (`main.go`)
- **#12** Reject non-POST methods on `/validate` with `405`.
- **#6** Bound the request body via `http.MaxBytesReader` (8 MiB) and add `ReadHeaderTimeout` / `ReadTimeout` / `WriteTimeout` / `IdleTimeout` to the HTTP server (Slowloris protection).
- **#7** Add `/healthz` and `/readyz` endpoints for probes.
- **#9** Enforce `MinVersion: TLS 1.2`.
- **#5** Log the configured listen address instead of a hardcoded `:8443`.
- Handle marshal/write errors in `sendResponse` (previously ignored).

### Deployment (`webhook-deployment.yaml`)
- **#8** `replicas: 2`, resource requests/limits, and HTTPS liveness/readiness probes.

### CI (`ci.yml`)
- **#11** Add `gofmt` check, `go vet`, race detector + coverage to the build job, and a dedicated `golangci-lint` job.

### Tests
- Cover non-POST method (405) and the health endpoint.
- Existing tests adjusted to be lint-clean (checked `resp.Body.Close`).

Verified locally: `go build`, `go vet`, `gofmt -l`, `go test -race`, and `golangci-lint run` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)